### PR TITLE
Next

### DIFF
--- a/server/springboard.py
+++ b/server/springboard.py
@@ -296,6 +296,7 @@ class ServerPanel:
 # build the user interface
 try:
 	from Tkinter import *
+	root = Tk()
 except:
 	import signal
 	#no Tkinter compiled in, command line only
@@ -314,7 +315,6 @@ except:
 	while True:
 		time.sleep(1000)
 else:
-	root = Tk()
 	panel = ConfigPanel(root)
 	root.mainloop()
 


### PR DESCRIPTION
Hey,

This adds the ability to run springboard.py on a python installation that doesn't have Tkinter installed or if it doesn't have a display.  This was necessary for my Buffalo Linkstation NAS and my headless ubuntu server to run the server.  Please test it to make sure that it works still with a GUI and then pull the changes.

Thanks,
-Randall
