### PR TITLE
Channel

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -14,6 +14,20 @@ h1(#install). INSTALLATION
 
 # Enjoy!
 
+h2. Adding support for auto-generated video thumbnails
+
+# "Download pyffmpeg 2.0":http://pyffmpeg.googlecode.com/files/pyffmpeg-2.0.tar.gz 
+
+# Extract pyffmpeg-2.0.tar.gz
+
+# Install the dependencies, on Ubuntu
+
+## sudo apt-get install cython python-numpy libavfilter-dev libavformat-dev libavutil-dev libavcodec-dev libswscale-dev python-dev
+
+## python setup.py build
+
+## sudo python setup.py install
+
 h2. License
 
 The server code in this package is to be distributed under the terms of the GPL. The client code is also GPL but with a special attribution exception for the Roku business entity (per their SDK license agreement.)

--- a/server/mymedia.py
+++ b/server/mymedia.py
@@ -604,7 +604,7 @@ def getdoc(key, path, base_dir, dirrange, config, recurse=False):
     range = ""
 
   doc = RSSDoc(
-      title="A Personal Music Feed",
+      title="A Personal %s Feed" % key.capitalize(),
       link="%s/feed?key=%s&dir=%s%s" % (key, server_base(config), relpath26(path, base_dir), range),
       description="My Media",
       lastBuildDate=datetime.datetime.now(),

--- a/server/mymedia.py
+++ b/server/mymedia.py
@@ -349,8 +349,11 @@ def getart(path):
     # create an thumbnail if possible
     thmb = thumbnail.create_thumbnail(path, size="large")
     if thmb != None:
+        # Since ROKU caches images based off URL, include mtime of the 
+        # thumbnail in the image URL
+        mtime = int(os.path.getmtime(thmb))
 	thmb = os.path.basename(thmb)
-	thmb = os.path.splitext(thmb)[0] + ".thumbnail"
+	thmb = os.path.splitext(thmb)[0] + "-%s.thumbnail" % (mtime)
     return thmb
 
   if is_photo(path):
@@ -824,7 +827,10 @@ class MediaHandler:
     name = song.name
     ext = os.path.splitext(os.path.split(name)[1] or "")[1].lower()
     if ext == ".thumbnail":
+      name, mtime = name.split("-", 1)
       name = os.path.splitext(name)[0] + ".png"
+      # Get the basename since the mtime is only used to keep the roku from caching the file 
+      # even if the thumbnail is updated
       ext = ".png"
       logging.debug("retrieving image data from thumbnail %s" % name)
       name = os.path.join(thumbnail.THUMBNAIL_DIRECTORY, "large", name)

--- a/server/rss_template.xml
+++ b/server/rss_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <rss version="2.0">
   <channel>
-    <title>MyMusic Feed</title>
+    <title>MyMedia Feed</title>
     {% for item in items %}
     <item>
       <title>{{ item.title }}</title>

--- a/server/thumbnail.py
+++ b/server/thumbnail.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# Copyright 2011, Michael Ihde
+# Distribute under the terms of the GNU General Public License
+# Version 2 or better
+
+# A python module that helps implement the thumbnail management standard
+# http://jens.triq.net/thumbnail-spec/index.html
+
+import os
+import sys
+import hashlib
+import random
+import binascii
+import mimetypes
+import re
+import tempfile
+import StringIO
+from PIL import Image
+from PIL import PngImagePlugin
+
+try:
+    import pyffmpeg
+except ImportError:
+    pyffmpeg = None
+
+# Per the specification, this is the only place but if you really
+# want to change THUMBNAIL_DIRECTORY, go ahead
+THUMBNAIL_DIRECTORY = os.path.expanduser("~/.thumbnails")
+NORMAL_SIZE = (128, 128)
+LARGE_SIZE = (256, 256)
+
+# Add some types that don't appear in the default list on some systems
+mimetypes.add_type("video/mp4", ".m4v")
+
+def create_thumbnail(filename, size="normal"):
+    # TODO If path is in THUMBNAIL_DIRECTORY, don't create a thumbnail
+
+    mimetype = mimetypes.guess_type(filename)[0]
+
+    uri = "file://%s" % os.path.normpath(os.path.abspath(filename))
+    m = hashlib.md5()
+    m.update(uri)
+    hashedname = binascii.hexlify(m.digest())
+    if size == "normal":
+      res = NORMAL_SIZE
+    elif size == "large":
+      res = LARGE_SIZE
+    else:
+        raise ValueError, "Invalid Size"
+
+    outfile = os.path.join(THUMBNAIL_DIRECTORY, size, hashedname + ".png")
+
+    # Determine if we really need to recreate a thumbnail
+    if os.path.exists(outfile):
+        stat = os.stat(filename)
+        im = Image.open(outfile)
+        try:
+            thmb_mtime = int(im.info["Thumb::MTime"])
+        except KeyError:
+            pass
+        except ValueError:
+            pass
+        else:
+            if (int(stat.st_mtime) == thmb_mtime):
+                return outfile
+
+
+    data = None
+    if re.match("video/\.*", mimetype):
+        data = create_video_thumbnail(filename)
+
+    if data == None:
+        return
+    # The temporary file should be placed into the same directory as the final
+    # thumbnail, because then you are sure that they lay on the same
+    # filesystem. This guarantees a fast renaming of the temporary file.
+    tmp_output = None
+    try:
+        if data != None:
+	    tmp_fd, tmp_path = tempfile.mkstemp(prefix=hashedname, suffix="-tmp.png" , dir=THUMBNAIL_DIRECTORY)
+	    tmp_output = os.fdopen(tmp_fd, "w")
+            tmp_output.write(data)
+    finally:
+        if tmp_output != None:
+	    tmp_output.close()
+
+    stat = os.stat(filename)
+
+    info = {"Thumb::URI": uri,
+            "Thumb::MTime": int(stat.st_mtime),
+            "Thumb::Size": stat.st_size,
+            "Thumb::Mimetype": mimetype}
+ 
+    if not os.path.exists(tmp_path):
+        print "Failure to create thumbnail"
+        return None
+
+    generate_png_thumb(tmp_path, res, info=info)
+
+    if os.path.exists(tmp_path):
+        os.rename(tmp_path, outfile)
+
+    return outfile
+
+def create_video_thumbnail(filename):
+    if pyffmpeg == None:
+        return None
+    reader = pyffmpeg.FFMpegReader(False)
+    reader.open(filename, pyffmpeg.TS_VIDEO_PIL)
+    vt=reader.get_tracks()[0]
+    # Pick something near the middle, the very start and very ends aren't
+    # usually very interesting
+    s = int(vt.duration() * 0.25)
+    f = int(vt.duration() * 0.75)
+    i = random.randint(s, f)
+    vt.seek_to_pts(i)
+    image=vt.get_current_frame()[2]
+    output = StringIO.StringIO()
+    image.save(output, "PNG")
+    return output.getvalue()
+
+def generate_png_thumb(filename, res, info={}):
+    """                                                                                                                                      
+    Uses code from public domain, Nick Galbreath
+    http://blog.modp.com/2007/08/python-pil-and-png-metadata-take-2.html
+    """
+    print filename
+    im = Image.open(filename)
+    im.thumbnail(res)
+
+    # these can be automatically added to Image.info dict                                                                              
+    # they are not user-added metadata
+    reserved = ('interlace', 'gamma', 'dpi', 'transparency', 'aspect')
+
+    meta = PngImagePlugin.PngInfo()
+    for k,v in info.items():
+        meta.add_text(k, str(v), 0)
+
+    # 8-bit, non-interlaced, PNG with full alpha transparency
+    im.save(filename, "PNG", pnginfo=meta)
+   
+if __name__ == "__main__":
+    for f in sys.argv[1:]:
+        outfile = create_thumbnail(os.path.abspath(f))
+        print "Created", outfile


### PR DESCRIPTION
A couple of fixes/enhancements in here:
1. Fix security hole where absolute paths could be passed to MediaHandler and returned
2. Use web.py exceptions when MediaHandler has issues
3. Auto-generate video thumbnails if pyffmpeg is available, follow the freedesktop thumbnail standard so that if other tools have already generated the thumbnail they are used by MyMedia
